### PR TITLE
지도 그리고 chart와 결합(Front) -> js #13

### DIFF
--- a/pctc-front/public/index.html
+++ b/pctc-front/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=0ed00b3cb3e60ff887b0375a881a9b12"></script>
     <title>컨테이너터미널 혼잡도 예측</title>
   </head>
   <body>

--- a/pctc-front/src/component/componentstyle.css
+++ b/pctc-front/src/component/componentstyle.css
@@ -24,5 +24,5 @@
 
 .footerview {
   background-color: coral;
-  height: 200px;
+  height: 100px;
 }

--- a/pctc-front/src/component/service_view/CPVS.js
+++ b/pctc-front/src/component/service_view/CPVS.js
@@ -1,31 +1,48 @@
 /* Level 3 */
 /* Congestion prediction and visualization service */
 /* 혼잡도 예측 및 시각화 서비스 */
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BarChart from './component/BarChart';
 import './serviceview.css'
 import { UserData } from './component/Data';
 
+const { kakao } = window;
 
 const CPVS = () => {
-  
+
   const [userData, setUserData] = useState({
     labels: UserData.map((x) => x.year),
     datasets: [{
       label: "Users Gained",
       data: UserData.map((x) => x.userGain),
-    },{
+    }, {
       label: "Users Gained2",
       data: UserData.map((x) => x.userLost),
     }]
   });
 
-  return(
+  useEffect(() => {
+    var container = document.getElementById('map');
+    var options = {
+      center: new kakao.maps.LatLng(35.106, 129.08),
+      level: 4,
+      draggable: false,
+    };
+
+    var map = new kakao.maps.Map(container, options);
+  }, []);
+
+  return (
     <div className='cpvs'>
-      <div style={{'fontSize': '2em', fontWeight:'bold', textAlign: 'center'}}>CPVS Area</div>
-      <div style={{width: '700px', height:'700px'}}>
-        <BarChart chartData={userData} />
+      {/* <div style={{ 'fontSize': '2em', fontWeight: 'bold', textAlign: 'center' }}>CPVS Area</div> */}
+      <div id="map" style={{ width: '100%', height: '100%' }}>
+        <div id="area-1"></div>
+        <div id="area-2"></div>
+        <div id="area-3"></div>
       </div>
+      {/* <div style={{ width: '700px', height: '700px' }}>
+        <BarChart chartData={userData} />
+      </div> */}
     </div>
   )
 }

--- a/pctc-front/src/component/service_view/serviceview.css
+++ b/pctc-front/src/component/service_view/serviceview.css
@@ -1,6 +1,6 @@
 .serviceview {
   background-color: blueviolet;
-  height: 500px;
+  height: 700px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -17,15 +17,54 @@
 }
 
 .cpvs {
-  box-sizing: border-box;
-  background-color: white;
   width: 60%;
   height: 90%;
   margin: 10px;
-  border: solid 3px #282828;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+}
+
+#map {
+  position: relative;
+  top: 0px;
+  left: 0px;
+  border: solid 1px #282828;
+  border-radius: 10px;
+  z-index: 1;
+}
+
+#area-1 {
+  position: relative;
+  top: 90px;
+  left: 140px;
+  border-radius: 50%;
+  width: 300px;
+  height: 200px;
+  transform: rotate(25deg);
+  background-color: #FF000033;
+  z-index: 2;
+}
+
+#area-2 {
+  position: relative;
+  top: 10px;
+  left: 430px;
+  border-radius: 50%;
+  width: 70px;
+  height: 70px;
+  /* transform: rotate(25deg); */
+  background-color: #FFFF0033;
+  z-index: 2;
+}
+
+#area-3 {
+  position: relative;
+  top: -80px;
+  left: 580px;
+  border-radius: 50%;
+  width: 150px;
+  height: 100px;
+  /* transform: rotate(25deg); */
+  background-color: #00FF0033;
+  z-index: 2;
 }
 
 .sadrs {
@@ -41,3 +80,4 @@
   height: 45%;
   border: solid 3px #282828;
 }
+


### PR DESCRIPTION
chart.js 대신 CSS로 간단하게 표현.
실제 반투명 색상타원으로 표시할거라면 css 표현으로 충분할 것으로 봄.
추후 요구사항에 따라 반영 고려.