### PR TITLE
Debugging Log

### DIFF
--- a/pctc-front-next/src/app/components/client/signin/Signin.tsx
+++ b/pctc-front-next/src/app/components/client/signin/Signin.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useState, useEffect } from 'react'
 
 

--- a/pctc-front-next/src/app/user/login/page.tsx
+++ b/pctc-front-next/src/app/user/login/page.tsx
@@ -37,7 +37,7 @@ export default function Login() {
             state: sessionStorage.getItem("PCTCLoginSuccess"),
             name: sessionStorage.getItem("PCTCName")
           });
-          router.push("/");
+          window.location.href = '/';
         });
     }
   }


### PR DESCRIPTION
로그인 페이지(client component)에서 sign을 재렌더링 할 방법이 없음.
>> 로그인 시에만 전체 하드 라우팅하는 것으로 해결.